### PR TITLE
Type spec errors found by dialyzer

### DIFF
--- a/include/elli.hrl
+++ b/include/elli.hrl
@@ -5,7 +5,7 @@
 
 -type path() :: binary().
 -type args() :: binary().
--type version() :: {1,0} | {1,1}.
+-type version() :: {0,9} | {1,0} | {1,1}.
 -type header() :: {Key::binary(), Value::binary() | string()}.
 -type headers() :: [header()].
 -type body() :: binary() | iolist().

--- a/src/elli_http.erl
+++ b/src/elli_http.erl
@@ -263,7 +263,8 @@ split_args(Qs) ->
 %% RECEIVE REQUEST
 %%
 
--spec get_headers(port(), term(), binary(), callback()) -> headers().
+-spec get_headers(port(), version(), binary(), callback()) ->
+                         {headers(), any()}.
 get_headers(_Socket, {0, 9}, _, _) ->
     {[], <<>>};
 get_headers(Socket, {1, _}, Buffer, Callback) ->
@@ -292,7 +293,7 @@ get_headers(Socket, Buffer, Headers, HeadersCount, {Mod, Args} = Callback) ->
             end
     end.
 
--spec get_body(port(), headers(), binary(), callback) -> body().
+-spec get_body(port(), headers(), binary(), callback()) -> body().
 get_body(Socket, Headers, Buffer, {Mod, Args}) ->
     case proplists:get_value(<<"Content-Length">>, Headers, undefined) of
         undefined ->


### PR DESCRIPTION
$ dialyzer --apps stdlib kernel -r deps --build_plt --output_plt .dialyzer.plt
$ dialyzer -Wno_return ebin/*beam --plt .dialyzer.plt 
...
elli_http.erl:266: Invalid type specification for function elli_http:get_headers/4. The success typing is (port(),{0 | 1,non_neg_integer()},binary(),{_,_}) -> {[{_,_}],binary()}
elli_http.erl:295: Invalid type specification for function elli_http:get_body/4. The success typing is (port(),[{_,_}],binary(),{_,_}) -> binary()
...
