### PR TITLE
Added http methods head and put to type spec of req.method

### DIFF
--- a/include/elli.hrl
+++ b/include/elli.hrl
@@ -28,7 +28,8 @@
 }).
 
 -record(req, {
-          method :: 'GET' | 'HEAD' | 'POST' | 'PUT',
+          method :: 'OPTIONS' | 'GET' | 'HEAD' | 'POST' |
+                    'PUT' | 'DELETE' | 'TRACE',
           path :: [binary()],
           args,
           raw_path :: binary(),


### PR DESCRIPTION
Elli is using erlang:decode_packet(http_bin, ..., ...) when decoding, which can return 'OPTIONS' | 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'TRACE'. Should I add in all to the type spec?
