### PR TITLE
Unnecessary function clause

### DIFF
--- a/src/elli_request.erl
+++ b/src/elli_request.erl
@@ -42,8 +42,6 @@ get_header(Key, #req{headers = Headers}, Default) ->
 get_arg(Key, #req{} = Req) ->
     get_arg(Key, Req, undefined).
 
-get_arg(_Key, #req{args = []}, Default) ->
-    Default;
 get_arg(Key, #req{args = Args}, Default) ->
     proplists:get_value(Key, Args, Default).
 


### PR DESCRIPTION
Function clause for empty args in get_args implements the same functionality as other function clause.
