### PR TITLE
Fixed type spec errors from dialyzer.

### DIFF
--- a/src/elli_http.erl
+++ b/src/elli_http.erl
@@ -122,8 +122,8 @@ handle_request(S, PrevB, Opts, {Mod, Args} = Callback) ->
             {close_or_keepalive(Req, UserHeaders), B2}
     end.
 
--spec mk_req(Method::http_method(), RawPath::binary(), RequestHeaders::headers(),
-             RequestBody::body(), V::version(), Socket::inet:socket(),
+-spec mk_req(Method::http_method(), {PathType::atom(), RawPath::binary()}, RequestHeaders::headers(),
+             RequestBody::body(), V::version(), Socket::inet:socket() | undefined,
              Callback::callback()) -> record(req).
 mk_req(Method, RawPath, RequestHeaders, RequestBody, V, Socket, Callback) ->
     {Mod, Args} = Callback,
@@ -361,7 +361,7 @@ get_headers(Socket, Buffer, Headers, HeadersCount, Opts, {Mod, Args} = Callback)
     end.
 
 -spec get_body(port(), headers(), binary(),
-               proplists:proplist(), callback()) -> body().
+               proplists:proplist(), callback()) -> {body(), binary()}.
 %% @doc: Fetches the full body of the request, if any is available.
 %%
 %% At the moment we don't need to handle large requests, so there is

--- a/src/elli_test.erl
+++ b/src/elli_test.erl
@@ -14,7 +14,7 @@
 -export([call/5]).
 
 -spec call(Method::http_method(), Path::binary(),
-           Headers::headers(), Body::body(), Opts::proplist:proplist()) ->
+           Headers::headers(), Body::body(), Opts::proplists:proplist()) ->
                   record(req).
 call(Method, Path, Headers, Body, Opts) ->
     Callback = proplists:get_value(callback, Opts),


### PR DESCRIPTION
Some spec fixes from dialyzer.

What do you think about the 'undefined' in elli_http:mk_req(...)? That how elli_test calls the function, and it works. :)
