### PR TITLE
Move the state definition of the elli handler cordinator.

### DIFF
--- a/include/elli.hrl
+++ b/include/elli.hrl
@@ -27,14 +27,6 @@
 
 -type timestamp() :: {integer(), integer(), integer()}.
 
-
--record(state, {socket,
-                acceptors,
-                open_reqs,
-                options,
-                callback :: callback()
-}).
-
 -record(req, {
           method :: http_method(),
           path :: [binary()],

--- a/src/elli.erl
+++ b/src/elli.erl
@@ -22,6 +22,12 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
 
+-record(state, {socket,
+                acceptors,
+                open_reqs,
+                options,
+                callback :: callback()
+}).
 
 %%%===================================================================
 %%% API


### PR DESCRIPTION
elli.hrl needs to be included by modules that modifies the req record.
