### PR TITLE
Fix process crash for unsupported protocol

### DIFF
--- a/src/elli_request.erl
+++ b/src/elli_request.erl
@@ -192,8 +192,10 @@ send_chunk(Ref, Data, Timeout) ->
             {error, timeout}
     end.
 
-is_ref_alive(Ref) ->
+is_ref_alive(Ref) when is_pid(Ref) ->
     case node(Ref) =:= node() of
         true -> is_process_alive(Ref);
         false -> rpc:call(node(Ref), erlang, is_process_alive, [Ref])
-    end.
+    end;
+is_ref_alive(_Ref) ->
+    false.


### PR DESCRIPTION
Fix for the process crash:

```
CRASH REPORT Process <0.18299.93> with 0 neighbours exited with reason: bad argument in call to erlang:node({error,not_supported}) in elli_request:is_ref_alive/1 line 144 in gen_server:terminate/6 line 747
```
