### PR TITLE
Catch errors from handle_event/3 callback when about to send response.

### DIFF
--- a/src/elli_http.erl
+++ b/src/elli_http.erl
@@ -237,7 +237,7 @@ handle_event(Mod, Name, EventArgs, ElliArgs) ->
         Mod:handle_event(Name, EventArgs, ElliArgs)
     catch
         EvClass:EvError ->
-            error_logger:error_msg("~p:handle_event/3 crashed ~p:~p ~p",
+            error_logger:error_msg("~p:handle_event/3 crashed ~p:~p~n~p",
                                    [Mod, EvClass, EvError,
                                     erlang:get_stacktrace()])
     end.


### PR DESCRIPTION
Hi, I made the catch thingie for the callback calls that we talked about. There are several more. Do you think it makes sence to catch them as well?
