### PR TITLE
Strip strings before converting to integers

### DIFF
--- a/include/elli.hrl
+++ b/include/elli.hrl
@@ -21,10 +21,9 @@
 
 -type range() :: {Offset::non_neg_integer(), Length::non_neg_integer()}.
 
--define(l2i(L), list_to_integer(string:strip(L))).
+-define(l2i(L), list_to_integer(L)).
 -define(i2l(I), integer_to_list(I)).
--define(b2i(I), list_to_integer(string:strip(binary_to_list(I)))).
-
+-define(b2i(I), list_to_integer(binary_to_list(I))).
 
 -type timestamp() :: {integer(), integer(), integer()}.
 

--- a/src/elli_http.erl
+++ b/src/elli_http.erl
@@ -386,7 +386,8 @@ get_body(Socket, Headers, Buffer, Opts, {Mod, Args} = Callback) ->
         undefined ->
             {<<>>, Buffer};
         ContentLengthBin ->
-            ContentLength = ?b2i(ContentLengthBin),
+            ContentLength = ?b2i(binary:replace(ContentLengthBin,
+                                                <<" ">>, <<>>, [global])),
 
             ok = check_max_size(Socket, ContentLength, Buffer, Opts, Callback),
 


### PR DESCRIPTION
We've been seeing that some browsers sends trailing whitespace after the the value of the Content-Length header, which causes the request handler to crash. This changes the b2i and l2i macros to strip the strings before converting them.
