### PR TITLE
Middleware to show better 4xx, 5xx responses

### DIFF
--- a/src/elli_middleware_error_responses.erl
+++ b/src/elli_middleware_error_responses.erl
@@ -1,0 +1,29 @@
+%% @doc: Add request reference to error response body as Elli middleware.
+%% Postprocesses all requests and add request's unique reference to response
+%% body.
+
+-module(elli_middleware_error_responses).
+-export([postprocess/3]).
+
+%%
+%% Postprocess handler
+%%
+
+postprocess(Req, {ResponseCode, Headers, Body} = Res, _Args)
+  when is_integer(ResponseCode) ->
+    case is_error(ResponseCode) of
+        false ->
+            Res;
+        true ->
+            Msg = io_lib:format("~nRequest: ~p", [elli_request:to_proplist(Req)]),
+            {ResponseCode, Headers, [Body, Msg]}
+    end;
+postprocess(_, Res, _) ->
+    Res.
+
+%%
+%% INTERNALS
+%%
+
+is_error(ResponseCode) ->
+    ResponseCode >= 400 andalso ResponseCode < 600.

--- a/test/elli_middleware_tests.erl
+++ b/test/elli_middleware_tests.erl
@@ -9,7 +9,8 @@ elli_test_() ->
      [
       ?_test(hello_world()),
       ?_test(short_circuit()),
-      ?_test(compress())
+      ?_test(compress()),
+      ?_test(error_responses())
      ]}.
 
 %%
@@ -58,6 +59,21 @@ compress() ->
     ?assertEqual(lists:flatten(lists:duplicate(86, "Hello World!")), body(Response3)).
 
 
+error_responses() ->
+    {ok, Response} = httpc:request("http://localhost:3002/foobarbaz"),
+    ?assertEqual(404, status(Response)),
+    ?assertMatch({match, _Captured}, re:run(body(Response), "Not Found")),
+    ?assertMatch({match, _Captured}, re:run(body(Response), "Request: ")),
+
+    {ok, Response1} = httpc:request("http://localhost:3002/crash"),
+    ?assertEqual(500, status(Response1)),
+    ?assertMatch({match, _Captured}, re:run(body(Response1), "Internal server error")),
+    ?assertMatch({match, _Captured}, re:run(body(Response1), "Request: ")),
+
+    {ok, Response2} = httpc:request("http://localhost:3002/403"),
+    ?assertEqual(403, status(Response2)),
+    ?assertMatch({match, _Captured}, re:run(body(Response2), "Forbidden")),
+    ?assertMatch({match, _Captured}, re:run(body(Response2), "Request: ")).
 
 
 
@@ -88,6 +104,7 @@ setup() ->
                                          {port, 514}]},
                       {elli_example_middleware, []},
                       {elli_middleware_compress, []},
+                      {elli_middleware_error_responses, []},
                       {elli_example_callback, []}
                      ]}
              ],


### PR DESCRIPTION
I've added exception handling in middleware process execution to postprocess also error responses.

Closes #46
