### PR TITLE
Moved type conversion short names to separate new hrl file.

### DIFF
--- a/include/elli.hrl
+++ b/include/elli.hrl
@@ -21,10 +21,6 @@
 
 -type range() :: {Offset::non_neg_integer(), Length::non_neg_integer()}.
 
--define(l2i(L), list_to_integer(L)).
--define(i2l(I), integer_to_list(I)).
--define(b2i(I), list_to_integer(binary_to_list(I))).
-
 -type timestamp() :: {integer(), integer(), integer()}.
 
 -record(req, {

--- a/src/elli_http.erl
+++ b/src/elli_http.erl
@@ -5,6 +5,7 @@
 %% closed either by the client timing out or explicitly by the user.
 -module(elli_http).
 -include("../include/elli.hrl").
+-include("elli_util.hrl").
 
 
 %% API

--- a/src/elli_request.erl
+++ b/src/elli_request.erl
@@ -1,5 +1,6 @@
 -module(elli_request).
 -include("../include/elli.hrl").
+-include("elli_util.hrl").
 
 -export([send_chunk/2
          , async_send_chunk/2

--- a/src/elli_util.erl
+++ b/src/elli_util.erl
@@ -1,5 +1,6 @@
 -module(elli_util).
 -include("../include/elli.hrl").
+-include("elli_util.hrl").
 
 -include_lib("kernel/include/file.hrl").
 

--- a/src/elli_util.hrl
+++ b/src/elli_util.hrl
@@ -1,0 +1,3 @@
+-define(l2i(L), list_to_integer(L)).
+-define(i2l(I), integer_to_list(I)).
+-define(b2i(I), list_to_integer(binary_to_list(I))).


### PR DESCRIPTION
This is placed in src not in include since it isn't meant to
be included from other applications.
This commit makes it easier to include elli.hrl in you app.
