### PR TITLE
Handle HttpError when using get_headers in elli_http

### DIFF
--- a/src/elli_http.erl
+++ b/src/elli_http.erl
@@ -354,6 +354,8 @@ get_headers(Socket, Buffer, Headers, HeadersCount, Opts, {Mod, Args} = Callback)
             get_headers(Socket, Rest, NewHeaders, HeadersCount + 1, Opts, Callback);
         {ok, http_eoh, Rest} ->
             {Headers, Rest};
+        {ok, {http_error, _}, Rest} ->
+            get_headers(Socket, Rest, Headers, HeadersCount, Opts, Callback);
         {more, _} ->
             case gen_tcp:recv(Socket, 0, header_timeout(Opts)) of
                 {ok, Data} ->


### PR DESCRIPTION
Add http_error clause when using get_headers to prevent errors such as:

```
May 26 08:08:01 live-erlang app@server:  <0.138.0> Elli request (pid <0.18293.808>) unexpectedly crashed:
{{case_clause,{ok,{http_error,<<67,111,110,110,116,45,116,0,0,121,112,101,58,32,97,112,112,108,105,99,97,116,105,111,110,47,120,45,119,119,119,45,102,111,114,109,45,117,114,108,101,110,99,111,100,101,100,13,10>>},<<"Content-length: 320\r\n\r\n">>}},[{elli_http,get_headers,6,[{file,"src/elli_http.erl"},{line,350}]},{elli_http,handle_request,4,[{file,"src/elli_http.erl"},{line,67}]},{elli_http,keepalive_loop,5,[{file,"src/elli_http.erl"},{line,52}]}]}
```
