### PR TITLE
Handle connections sending http_response

### DIFF
--- a/src/elli_http.erl
+++ b/src/elli_http.erl
@@ -331,6 +331,9 @@ get_request(Socket, Buffer, Options, {Mod, Args} = Callback) ->
             handle_event(Mod, request_parse_error, [Buffer], Args),
             send_bad_request(Socket),
             gen_tcp:close(Socket),
+            exit(normal);
+        {ok, {http_response, _, _, _}, _} ->
+            gen_tcp:close(Socket),
             exit(normal)
     end.
 


### PR DESCRIPTION
Certain misconfigured proxy servers send http_response packets. They typically look like 

```
<0.19681.8077> CRASH REPORT Process <0.19681.8077> with 0 neighbours crashed with reason: 
no case clause matching {ok,{http_response,{1,1},200,<<"OK">>},
<<"Connection: Keep-Alive\r\nContent-Length: 12\r\nDate: Wed, 28 Aug 2013 19:25:52 GMT\r\n
Access-Control-Allow-Origin: *\r\nVary: Accept-Encoding\r\nContent-Type: application/json\r\n\r\n">>}
in elli_http:get_request/4 line 313
```

This patch handles such connections and ignores them.
