### PR TITLE
Remove all empty path parts from the parsed url.

### DIFF
--- a/src/elli_http.erl
+++ b/src/elli_http.erl
@@ -513,13 +513,9 @@ parse_path({absoluteURI, _Scheme, _Host, _Port, Path}) ->
 parse_path(_) ->
     {error, unsupported_uri}.
 
-split_path(<<"/", Path/binary>>) ->
-    path_trim(binary:split(Path, [<<"/">>], [global]));
 split_path(Path) ->
-    path_trim(binary:split(Path, [<<"/">>], [global])).
-
-path_trim(Path) ->
-    [P || P <- Path, P =/= <<>>].
+    [P || P <- binary:split(Path, [<<"/">>], [global]),
+          P =/= <<>>].
 
 %% @doc: Splits the url arguments into a proplist. Lifted from
 %% cowboy_http:x_www_form_urlencoded/2


### PR DESCRIPTION
Trim only removes empty binaries at the end
Eg: elli_http:parse_path({abs_path, <<"//map//stuff.json">>})
now: {ok, {..., [<<"map">>,<<"stuff.json">>], ...}}.
previously: {ok, {..., [<<>>, <<"map">>,<<>>,<<"stuff.json">>], ...}}.

We could remove the first clause or split_path/1, and then make the list comprehension in split_path. What do you think? 
