### PR TITLE
Moved types from header to elli module.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ eunit:
 	./rebar eunit skip_deps=true
 
 init_dialyzer:
-	dialyzer --apps stdlib kernel erts crypto --build_plt --output_plt .dialyzer.plt
+	dialyzer --apps stdlib kernel erts ssl public_key crypto --build_plt --output_plt .dialyzer.plt
 
 dialyzer: compile
-	dialyzer --no_native -Wno_return -r ebin --plt .dialyzer.plt
+	dialyzer --no_native -Wno_return -Werror_handling -Wunderspecs -Wno_match -r ebin --plt .dialyzer.plt

--- a/include/elli.hrl
+++ b/include/elli.hrl
@@ -1,44 +1,12 @@
 
--type callback_mod() :: module().
--type callback_args() :: any().
--type callback() :: {callback_mod(), callback_args()}.
-
--type path() :: binary().
--type args() :: binary().
--type version() :: {0,9} | {1,0} | {1,1}.
--type header() :: {Key::binary(), Value::binary() | string()}.
--type headers() :: [header()].
--type body() :: binary() | iolist().
--type response() :: iolist().
--type http_method() :: 'OPTIONS' | 'GET' | 'HEAD' | 'POST' |
-                       'PUT' | 'DELETE' | 'TRACE' | binary().
-                       %% binary for other http methods
-
--type response_code() :: 100..999.
--type connection_token_atom() :: keep_alive | close.
-
--type http_range() :: {First::non_neg_integer(), Last::non_neg_integer()} |
-                      {offset, Offset::non_neg_integer()} |
-                      {suffix, Length::pos_integer()}.
-
--type range() :: {Offset::non_neg_integer(), Length::non_neg_integer()}.
-
--type timestamp() :: {integer(), integer(), integer()}.
--type elli_event() :: elli_startup |
-                      bad_request | file_error |
-                      chunk_complete | request_complete |
-                      request_throw | request_error | request_exit |
-                      request_closed | request_parse_error |
-                      client_closed | client_timeout.
-
 -record(req, {
-          method :: http_method(),
+          method :: elli:http_method(),
           path :: [binary()],
           args :: [{binary(), any()}],
           raw_path :: binary(),
-          version :: version(),
-          headers :: headers(),
-          body :: body(),
+          version :: elli:version(),
+          headers :: elli:headers(),
+          body :: elli:body(),
           pid :: pid(),
           socket :: inet:socket()
 }).

--- a/src/elli.erl
+++ b/src/elli.erl
@@ -23,8 +23,50 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
 
+
+%%%===================================================================
+%%% TYPES
+%%%===================================================================
+
+-type callback_mod() :: module().
+-type callback_args() :: any().
+-type callback() :: {callback_mod(), callback_args()}.
+
+-type path() :: binary().
+-type args() :: binary().
+-type version() :: {0,9} | {1,0} | {1,1}.
+-type header() :: {Key::binary(), Value::binary() | string()}.
+-type headers() :: [header()].
+-type body() :: binary() | iolist().
+-type response() :: iolist().
+-type http_method() :: 'OPTIONS' | 'GET' | 'HEAD' | 'POST' |
+                       'PUT' | 'DELETE' | 'TRACE' | binary().
+                       %% binary for other http methods
+
+-type response_code() :: 100..999.
+-type connection_token_atom() :: keep_alive | close.
+
+-type http_range() :: {First::non_neg_integer(), Last::non_neg_integer()} |
+                      {offset, Offset::non_neg_integer()} |
+                      {suffix, Length::pos_integer()}.
+
+-type range() :: {Offset::non_neg_integer(), Length::non_neg_integer()}.
+
+-type timestamp() :: {integer(), integer(), integer()}.
+-type elli_event() :: elli_startup |
+                      bad_request | file_error |
+                      chunk_complete | request_complete |
+                      request_throw | request_error | request_exit |
+                      request_closed | request_parse_error |
+                      client_closed | client_timeout.
+
+
 -type req() :: record(req).
--export_type([req/0, body/0]).
+
+-export_type([callback_mod/0, callback_args/0, callback/0, path/0,
+    args/0, version/0, header/0, headers/0, body/0, response/0,
+    http_method/0, response_code/0, connection_token_atom/0, 
+    http_range/0, range/0, timestamp/0, elli_event/0, req/0]).
 
 -record(state, {socket :: port(),
                 acceptors :: [pid()],

--- a/src/elli_handler.erl
+++ b/src/elli_handler.erl
@@ -1,6 +1,6 @@
 -module(elli_handler).
 -include("elli.hrl").
 
--callback handle(Req :: #req{}, callback_args()) ->
-    ignore | {response_code(), [tuple()], binary()} | {ok, [tuple()], binary()}.
--callback handle_event(Event :: elli_event(), Args :: [tuple()], Config :: [tuple()]) -> ok.
+-callback handle(Req :: #req{}, elli:callback_args()) ->
+    ignore | {elli:response_code(), [tuple()], binary()} | {ok, [tuple()], binary()}.
+-callback handle_event(Event :: elli:elli_event(), Args :: [tuple()], Config :: [tuple()]) -> ok.

--- a/src/elli_http.erl
+++ b/src/elli_http.erl
@@ -18,11 +18,11 @@
          parse_path/1, keepalive_loop/3, keepalive_loop/5]).
 
 
--spec start_link(pid(), port(), proplists:proplist(), callback()) -> pid().
+-spec start_link(pid(), port(), proplists:proplist(), elli:callback()) -> pid().
 start_link(Server, ListenSocket, Options, Callback) ->
     proc_lib:spawn_link(?MODULE, accept, [Server, ListenSocket, Options, Callback]).
 
--spec accept(pid(), port(), proplists:proplist(), callback()) -> ok.
+-spec accept(pid(), port(), proplists:proplist(), elli:callback()) -> ok.
 %% @doc: Accept on the socket until a client connects. Handles the
 %% request, then loops if we're using keep alive or chunked
 %% transfer. If accept doesn't give us a socket within 10 seconds, we
@@ -58,7 +58,7 @@ keepalive_loop(Socket, NumRequests, Buffer, Options, Callback) ->
             ok
     end.
 
--spec handle_request(port(), binary(), proplists:proplist(), callback()) ->
+-spec handle_request(port(), binary(), proplists:proplist(), elli:callback()) ->
                             {'keep_alive' | 'close', binary()}.
 %% @doc: Handle a HTTP request that will possibly come on the
 %% socket. Returns the appropriate connection token and any buffer
@@ -123,9 +123,9 @@ handle_request(S, PrevB, Opts, {Mod, Args} = Callback) ->
             {close_or_keepalive(Req, UserHeaders), B2}
     end.
 
--spec mk_req(Method::http_method(), {PathType::atom(), RawPath::binary()}, RequestHeaders::headers(),
-             RequestBody::body(), V::version(), Socket::inet:socket() | undefined,
-             Callback::callback()) -> record(req).
+-spec mk_req(Method::elli:http_method(), {PathType::atom(), RawPath::binary()}, RequestHeaders::elli:headers(),
+             RequestBody::elli:body(), V::elli:version(), Socket::inet:socket() | undefined,
+             Callback::elli:callback()) -> elli:req().
 mk_req(Method, RawPath, RequestHeaders, RequestBody, V, Socket, Callback) ->
     {Mod, Args} = Callback,
     case parse_path(RawPath) of
@@ -163,9 +163,9 @@ send_response(Socket, Method, Code, Headers, UserBody, {Mod, Args}) ->
     end.
 
 
--spec send_file(Socket::inet:socket(), Code::response_code(), Headers::headers(),
-                Filename::file:filename(), Range::range(),
-                Callback::callback()) -> ok.
+-spec send_file(Socket::inet:socket(), Code::elli:response_code(), Headers::elli:headers(),
+                Filename::file:filename(), Range::elli:range(),
+                Callback::elli:callback()) -> ok.
 %% @doc: Sends a HTTP response to the client where the body is the
 %% contents of the given file.  Assumes correctly set response code
 %% and headers.
@@ -337,8 +337,8 @@ get_request(Socket, Buffer, Options, {Mod, Args} = Callback) ->
             exit(normal)
     end.
 
--spec get_headers(port(), version(), binary(), proplists:proplist(), callback()) ->
-                         {headers(), any()}.
+-spec get_headers(port(), elli:version(), binary(), proplists:proplist(), elli:callback()) ->
+                         {elli:headers(), any()}.
 get_headers(_Socket, {0, 9}, _, _, _) ->
     {[], <<>>};
 get_headers(Socket, {1, _}, Buffer, Opts, Callback) ->
@@ -375,8 +375,8 @@ get_headers(Socket, Buffer, Headers, HeadersCount, Opts, {Mod, Args} = Callback)
             end
     end.
 
--spec get_body(port(), headers(), binary(),
-               proplists:proplist(), callback()) -> {body(), binary()}.
+-spec get_body(port(), elli:headers(), binary(),
+               proplists:proplist(), elli:callback()) -> {elli:body(), binary()}.
 %% @doc: Fetches the full body of the request, if any is available.
 %%
 %% At the moment we don't need to handle large requests, so there is

--- a/src/elli_request.erl
+++ b/src/elli_request.erl
@@ -82,14 +82,14 @@ post_arg(Key, #req{} = Req, Default) ->
     proplists:get_value(Key, body_qs(Req), Default).
 
 
--spec get_args(#req{}) -> QueryArgs :: proplists:proplist().
+-spec get_args(elli:req()) -> QueryArgs :: proplists:proplist().
 %% @doc Returns a proplist of keys and values of the original query
 %%      string.  Both keys and values in the returned proplists will
 %%      be binaries or the atom `true' in case no value was supplied
 %%      for the query key.
 get_args(#req{args = Args}) -> Args.
 
--spec query_str(#req{}) -> QueryStr :: binary().
+-spec query_str(elli:req()) -> QueryStr :: binary().
 %% @doc Calculates the query string associated with the given Request
 %% as a binary.
 query_str(#req{raw_path = Path}) ->
@@ -99,7 +99,7 @@ query_str(#req{raw_path = Path}) ->
     end.
 
 
--spec get_range(#req{}) -> [http_range()] | parse_error.
+-spec get_range(elli:req()) -> [elli:http_range()] | parse_error.
 %% @doc: Parses the Range header from the request.
 %% The result is either a byte_range_set() or the atom `parse_error'.
 %% Use elli_util:normalize_range/2 to get a validated, normalized range.
@@ -111,7 +111,7 @@ get_range(#req{headers = Headers})  ->
     end.
 
 
--spec parse_range_set(Bin::binary()) -> [http_range()] | parse_error.
+-spec parse_range_set(Bin::binary()) -> [elli:http_range()] | parse_error.
 
 parse_range_set(<<ByteRangeSet/binary>>) ->
     RangeBins = binary:split(ByteRangeSet, <<",">>, [global]),
@@ -122,7 +122,7 @@ parse_range_set(<<ByteRangeSet/binary>>) ->
         false -> Parsed
     end.
 
--spec parse_range(Bin::binary()) -> http_range() | parse_error.
+-spec parse_range(Bin::binary()) -> elli:http_range() | parse_error.
 
 parse_range(<<$-, SuffixBin/binary>>) ->
     %% suffix-byte-range

--- a/src/elli_test.erl
+++ b/src/elli_test.erl
@@ -13,9 +13,9 @@
 
 -export([call/5]).
 
--spec call(Method::http_method(), Path::binary(),
-           Headers::headers(), Body::body(), Opts::proplists:proplist()) ->
-                  record(req).
+-spec call(Method::elli:http_method(), Path::binary(),
+           Headers::elli:headers(), Body::elli:body(), Opts::proplists:proplist()) ->
+                  elli:req().
 call(Method, Path, Headers, Body, Opts) ->
     Callback = proplists:get_value(callback, Opts),
     CallbackArgs = proplists:get_value(callback_args, Opts),

--- a/src/elli_util.erl
+++ b/src/elli_util.erl
@@ -10,7 +10,7 @@
         ]).
 
 -spec normalize_range(RangeOrSet::any(), Size::integer()) ->
-                             range() | undefined | invalid_range.
+                             elli:range() | undefined | invalid_range.
 %% @doc: If a valid byte-range, or byte-range-set of size 1
 %% is supplied, returns a normalized range in the format
 %% {Offset, Length}. Returns undefined when an empty byte-range-set
@@ -36,7 +36,7 @@ normalize_range([], _Size) -> undefined;
 normalize_range(_, _Size) -> invalid_range.
 
 
--spec encode_range(Range::range() | invalid_range,
+-spec encode_range(Range::elli:range() | invalid_range,
                    Size::non_neg_integer()) -> ByteRange::iolist().
 %% @doc: Encode Range to a Content-Range value.
 encode_range(Range, Size) ->


### PR DESCRIPTION
Type specification should not be placed in hrl files. They should be exported from a module. Placing them in hrl files also makes it hard to document them, because edoc will not look at the hrl file. I've moved them to elli.erl.
