### PR TITLE
Elli should return 500 for handlers returning bogus responses

### DIFF
--- a/include/elli.hrl
+++ b/include/elli.hrl
@@ -29,7 +29,8 @@
                       chunk_complete | request_complete |
                       request_throw | request_error | request_exit |
                       request_closed | request_parse_error |
-                      client_closed | client_timeout.
+                      client_closed | client_timeout |
+                      invalid_return.
 
 -record(req, {
           method :: http_method(),

--- a/src/elli_example_callback.erl
+++ b/src/elli_example_callback.erl
@@ -163,6 +163,9 @@ handle('GET', [<<"403">>], _Req) ->
     %% authentication/authorization
     throw({403, [], <<"Forbidden">>});
 
+handle('GET', [<<"invalid_return">>], _Req) ->
+    {invalid_return};
+
 handle(_, _, _Req) ->
     {404, [], <<"Not Found">>}.
 
@@ -215,6 +218,11 @@ handle_event(request_complete, [_Request,
 handle_event(request_throw, [_Request, _Exception, _Stacktrace], _) -> ok;
 handle_event(request_error, [_Request, _Exception, _Stacktrace], _) -> ok;
 handle_event(request_exit, [_Request, _Exception, _Stacktrace], _) -> ok;
+
+%% invalid_return is sent if the user callback code returns a term not
+%% understood by elli, see elli_http:execute_callback/1.
+%% After triggering this event, a generated response is sent to the user.
+handle_event(invalid_return, [_Request, _ReturnValue], _) -> ok;
 
 
 %% chunk_complete fires when a chunked response is completely

--- a/src/elli_handler.erl
+++ b/src/elli_handler.erl
@@ -3,4 +3,4 @@
 
 -callback handle(Req :: #req{}, callback_args()) ->
     ignore | {response_code(), [tuple()], binary()} | {ok, [tuple()], binary()}.
--callback handle_event(Event :: elli_event(), Args :: [tuple()], Config :: [tuple()]) -> ok.
+-callback handle_event(Event :: elli_event(), Args :: [term()], Config :: [tuple()]) -> ok.

--- a/src/elli_http.erl
+++ b/src/elli_http.erl
@@ -220,7 +220,10 @@ execute_callback(#req{callback = {Mod, Args}} = Req) ->
         {HttpCode, Headers, {file, Filename, Range}} ->
             {file, HttpCode, Headers, Filename, Range};
         {HttpCode, Headers, Body}             -> {response, HttpCode, Headers, Body};
-        {HttpCode, Body}                      -> {response, HttpCode, [], Body}
+        {HttpCode, Body}                      -> {response, HttpCode, [], Body};
+        Unexpected                            ->
+            handle_event(Mod, invalid_return, [Req, Unexpected], Args),
+            {response, 500, [], <<"Internal server error">>}
     catch
         throw:{ResponseCode, Headers, Body} when is_integer(ResponseCode) ->
             {response, ResponseCode, Headers, Body};


### PR DESCRIPTION
Instead of a silent death and subsequent socket close - the elli process dies in a call to `iolist_size` - treat invalid handler responses as errors and inform the library user.
