### PR TITLE
fix ssl acceptor drain

### DIFF
--- a/src/elli_http.erl
+++ b/src/elli_http.erl
@@ -39,6 +39,8 @@ accept(Server, ListenSocket, Options, Callback) ->
             ?MODULE:accept(Server, ListenSocket, Options, Callback);
         {error, econnaborted} ->
             ?MODULE:accept(Server, ListenSocket, Options, Callback);
+        {error, {tls_alert, _}} ->
+            ?MODULE:accept(Server, ListenSocket, Options, Callback);
         {error, closed} ->
             ok;
         {error, Other} ->

--- a/src/elli_tcp.erl
+++ b/src/elli_tcp.erl
@@ -38,6 +38,8 @@ accept({ssl, Socket}, Timeout) ->
             case ssl:ssl_accept(S, Timeout) of
                 ok ->
                     {ok, {ssl, S}};
+                {error, closed} ->
+                    {error, econnaborted};
                 {error, Reason} ->
                     {error, Reason}
             end;


### PR DESCRIPTION
elli when configured to use SSL/TLS will run out of acceptors after
_MinAcceptors_ failed SSL/TLS handshakes.
This patch takes care of ssl:ssl_accept/2 returning {error, closed} or
{error, {tls_alert, _}}.
