### PR TITLE
elli_request:body_qs/1 ignore content-type when body is empty.

### DIFF
--- a/src/elli_request.erl
+++ b/src/elli_request.erl
@@ -79,6 +79,7 @@ get_arg_decoded(Key, #req{args = Args}, Default) ->
     list_to_binary(http_uri:decode(binary_to_list(EncodedValue))).
 
 %% @doc Parses application/x-www-form-urlencoded body into a proplist
+body_qs(#req{body = <<>>}) -> [];
 body_qs(#req{body = Body} = Req) ->
     case get_header(<<"Content-Type">>, Req) of
         <<"application/x-www-form-urlencoded">> ->


### PR DESCRIPTION
Perhaps an unusual use case, but it feels wrong to crash when calling `body_qs` on a post request with empty body (and no content type, granted, but that was the case when using curl, at least).
