### PR TITLE
[issue#88] -- Fix for elli_http:chunk_loop/1

### DIFF
--- a/src/elli_http.erl
+++ b/src/elli_http.erl
@@ -256,8 +256,9 @@ start_chunk_loop(Socket) ->
     ?MODULE:chunk_loop(Socket).
 
 chunk_loop(Socket) ->
+    {_SockType, InnerSocket} = Socket,
     receive
-        {tcp_closed, Socket} ->
+        {tcp_closed, InnerSocket} ->
             {error, client_closed};
 
         {chunk, close} ->

--- a/test/elli_http_tests.erl
+++ b/test/elli_http_tests.erl
@@ -1,0 +1,25 @@
+-module(elli_http_tests).
+-include_lib("eunit/include/eunit.hrl").
+-include("elli.hrl").
+
+%% UNIT TESTS
+
+chunk_loop_test_() ->
+    fun ()->
+        Here = self(),
+        ChunkLoopWrapper = fun() ->
+          Result = elli_http:chunk_loop({some_type, some_socket}),
+          Here ! Result,
+          ok
+        end,
+
+        Pid = spawn_link(ChunkLoopWrapper),
+        Pid ! {tcp_closed, some_socket},
+        Message = receive
+          X -> X
+        after
+          1 -> fail
+        end,
+
+        ?assertEqual({error, client_closed}, Message)
+    end.


### PR DESCRIPTION
- correct message matching in elli_http:chunk_loop/1 receive block
- basic unit test

## Note:

I had to struggle a bit to learn a bit of eunit,
so `tests/elli_http_tests.erl` doesn't really follow your conventions, sorry.....

I'll be glad to react on suggestions, how to make it more sound.

Cheers,
A