### PR TITLE
changing record specs to be compatible with  Erlang/OTP 18.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {erl_first_files, ["src/elli_handler.erl"]}.
-{erl_opts, [debug_info]}.
+{erl_opts, [debug_info, {i, "include"}]}.
 {cover_enabled, true}.
 {deps, []}.
 {xref_checks, [undefined_function_calls,locals_not_used]}.

--- a/src/elli.erl
+++ b/src/elli.erl
@@ -7,7 +7,7 @@
 %%
 -module(elli).
 -behaviour(gen_server).
--include("../include/elli.hrl").
+-include("elli.hrl").
 
 %% API
 -export([start_link/0,
@@ -23,7 +23,7 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
 
--type req() :: record(req).
+-type req() :: #req{}.
 -export_type([req/0, body/0, headers/0]).
 
 -record(state, {socket :: elli_tcp:socket(),

--- a/src/elli_example_callback.erl
+++ b/src/elli_example_callback.erl
@@ -10,7 +10,7 @@
 -export([handle/2, handle_event/3]).
 -export([chunk_loop/1]).
 
--include("../include/elli.hrl").
+-include("elli.hrl").
 -behaviour(elli_handler).
 
 -include_lib("kernel/include/file.hrl").

--- a/src/elli_http.erl
+++ b/src/elli_http.erl
@@ -4,8 +4,8 @@
 %% connects. It then handles requests on that connection until it's
 %% closed either by the client timing out or explicitly by the user.
 -module(elli_http).
--include("../include/elli.hrl").
--include("../include/elli_util.hrl").
+-include("elli.hrl").
+-include("elli_util.hrl").
 
 
 %% API
@@ -455,7 +455,7 @@ check_max_size(Socket, ContentLength, Buffer, Opts, {Mod, Args}) ->
 -spec mk_req(Method::http_method(), {PathType::atom(), RawPath::binary()},
              RequestHeaders::headers(), RequestBody::body(), V::version(),
              Socket::elli_tcp:socket() | undefined, Callback::callback()) ->
-                    record(req).
+             #req{}.
 mk_req(Method, RawPath, RequestHeaders, RequestBody, V, Socket, Callback) ->
     {Mod, Args} = Callback,
     case parse_path(RawPath) of

--- a/src/elli_request.erl
+++ b/src/elli_request.erl
@@ -1,5 +1,5 @@
 -module(elli_request).
--include("../include/elli.hrl").
+-include("elli.hrl").
 -include("elli_util.hrl").
 
 -export([send_chunk/2

--- a/src/elli_test.erl
+++ b/src/elli_test.erl
@@ -9,13 +9,13 @@
 
 -module(elli_test).
 
--include("../include/elli.hrl").
+-include("elli.hrl").
 
 -export([call/5]).
 
 -spec call(Method::http_method(), Path::binary(),
            Headers::headers(), Body::body(), Opts::proplists:proplist()) ->
-                  record(req).
+           #req{}.
 call(Method, Path, Headers, Body, Opts) ->
     Callback = proplists:get_value(callback, Opts),
     CallbackArgs = proplists:get_value(callback_args, Opts),

--- a/src/elli_util.erl
+++ b/src/elli_util.erl
@@ -1,5 +1,5 @@
 -module(elli_util).
--include("../include/elli.hrl").
+-include("elli.hrl").
 -include("elli_util.hrl").
 
 -include_lib("kernel/include/file.hrl").


### PR DESCRIPTION
Compilation failed for me due to problems with the record definition.
Seems to be fixed now, please review.