### PR TITLE
Add inets as a dependency

### DIFF
--- a/src/elli.app.src
+++ b/src/elli.app.src
@@ -5,7 +5,8 @@
   {registered, []},
   {applications, [
                   kernel,
-                  stdlib
+                  stdlib,
+                  inets
                  ]},
   {env, []},
 


### PR DESCRIPTION
This adds `inets` as a dependency (used in https://github.com/eproxus/elli/blob/master/src/elli_request.erl#L81) so that Elli can be properly used in Erlang releases.
