### PR TITLE
move accepted cast to after ssl:transport_accept but before ssl_accept

### DIFF
--- a/src/elli_http.erl
+++ b/src/elli_http.erl
@@ -30,10 +30,9 @@ start_link(Server, ListenSocket, Options, Callback) ->
 %% transfer. If accept doesn't give us a socket within a configurable
 %% timeout, we loop to allow code upgrades of this module.
 accept(Server, ListenSocket, Options, Callback) ->
-    case catch elli_tcp:accept(ListenSocket, accept_timeout(Options)) of
+    case catch elli_tcp:accept(ListenSocket, Server, accept_timeout(Options)) of
         {ok, Socket} ->
             t(accepted),
-            gen_server:cast(Server, accepted),
             ?MODULE:keepalive_loop(Socket, Options, Callback);
         {error, timeout} ->
             ?MODULE:accept(Server, ListenSocket, Options, Callback);
@@ -557,13 +556,13 @@ split_path(Path) ->
 %% cowboy_http:x_www_form_urlencoded/2
 -spec split_args(binary()) -> list({binary(), binary() | true}).
 split_args(<<>>) ->
-	[];
+    [];
 split_args(Qs) ->
-	Tokens = binary:split(Qs, <<"&">>, [global, trim]),
-	[case binary:split(Token, <<"=">>) of
-		[Token] -> {Token, true};
-		[Name, Value] -> {Name, Value}
-	end || Token <- Tokens].
+    Tokens = binary:split(Qs, <<"&">>, [global, trim]),
+    [case binary:split(Token, <<"=">>) of
+        [Token] -> {Token, true};
+        [Name, Value] -> {Name, Value}
+    end || Token <- Tokens].
 
 
 %%

--- a/src/elli_tcp.erl
+++ b/src/elli_tcp.erl
@@ -2,7 +2,7 @@
 %% mochiweb_socket.erl
 
 -module(elli_tcp).
--export([listen/3, accept/2, recv/3, send/2, close/1, setopts/2, sendfile/5, peername/1]).
+-export([listen/3, accept/3, recv/3, send/2, close/1, setopts/2, sendfile/5, peername/1]).
 
 -export_type([socket/0]).
 
@@ -25,16 +25,18 @@ listen(ssl, Port, Opts) ->
     end.
 
 
-accept({plain, Socket}, Timeout) ->
+accept({plain, Socket}, Server, Timeout) ->
     case gen_tcp:accept(Socket, Timeout) of
         {ok, S} ->
+            gen_server:cast(Server, accepted),
             {ok, {plain, S}};
         {error, Reason} ->
             {error, Reason}
     end;
-accept({ssl, Socket}, Timeout) ->
+accept({ssl, Socket}, Server, Timeout) ->
     case ssl:transport_accept(Socket, Timeout) of
         {ok, S} ->
+            gen_server:cast(Server, accepted),
             case ssl:ssl_accept(S, Timeout) of
                 ok ->
                     {ok, {ssl, S}};


### PR DESCRIPTION
For slow clients, like mobile clients, waiting to send the `accepted` message until after the ssl handshake as completed will hurt overall performance because new acceptors won't be spawned. This patch moves the `accepted` to before the handshake but after the transport accept to resolve this issue.