### PR TITLE
Add markdown links for alternative webservers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,14 @@ from the big names.
 
 ## Why another webserver? Isn't this just the NIH syndrome?
 
-Yaws, Mochiweb, Misultin and Cowboy are great projects, hardened over
-time and full of very useful features for web development. If you
-value developer productivity, Yaws is an excellent choice. If you want
-a fast and lightweight server, Mochiweb and Cowboy are excellent
-choices.
+[Yaws](https://github.com/klacke/yaws),
+[Mochiweb](https://github.com/mochi/mochiweb),
+[Misultin](https://github.com/ostinelli/misultin), and
+[Cowboy](https://github.com/ninenines/cowboy) are great projects,
+hardened over time and full of very useful features for web
+development. If you value developer productivity, Yaws is an
+excellent choice. If you want a fast and lightweight server, Mochiweb
+and Cowboy are excellent choices.
 
 Having used and studied all of these projects, we believed that if we
 merged some of the existing ideas and added some ideas from other


### PR DESCRIPTION
This PR adds links for the alternative web servers listed in the README file. I was digging through the README and wasn't previously aware of Yaws, Mochiweb, or Misultin, and needed to look up those projects individually on github to do further research. It seemed like it might be useful to other users in the future to reference those projects directly from links in the README rather than needing to research those on their own.

I rendered the markdown in-browser to test, and the links still display properly inline as they do currently on master, only with the addition of the links to the individual projects.