### PR TITLE
Add callback after opening listening socket

### DIFF
--- a/src/elli.erl
+++ b/src/elli.erl
@@ -117,6 +117,8 @@ init([Opts]) ->
                                                     | SSLSockOpts
                                                    ]),
 
+    ok = Callback:handle_event(elli_socket, Socket, CallbackArgs),
+
     Acceptors = ets:new(acceptors, [private, set]),
     StartAcc  = fun() ->
         Pid = elli_http:start_link(self(), Socket, Options, {Callback, CallbackArgs}),

--- a/src/elli_example_callback.erl
+++ b/src/elli_example_callback.erl
@@ -215,6 +215,10 @@ chunk_loop(Ref, N) ->
 %% tree.
 handle_event(elli_startup, [], _) -> ok;
 
+%% elli_socket callback is sent when Elli have opened listening socket.
+%% You can get or change socket opts.
+handle_event(elli_socket, _SocketRef, _) -> ok;
+
 %% request_complete fires *after* Elli has sent the response to the
 %% client. Timings contains timestamps of events like when the
 %% connection was accepted, when request parsing finished, when the


### PR DESCRIPTION
I added new callback elli_socket right after creating of listening socket. It is useful if you need change any socket opts or get some socket opts. I use it for determining port number after automatic port allocation.